### PR TITLE
feat: support absolute paths for `quarkus.helm.output-directory`

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmChartConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmChartConfig.java
@@ -103,8 +103,12 @@ public class HelmChartConfig {
     Map<String, ValueReferenceConfig> values;
 
     /**
-     * The output folder in which to place the Helm generated folder. By default, it will be generated in the folder named
-     * "helm".
+     * The output folder in which to place the Helm generated folder. The folder is relative to the target output directory
+     * in Quarkus that is also configurable using the property `quarkus.package.output-directory`.
+     *
+     * It also supports absolute paths.
+     *
+     * By default, it will be generated in the folder named "helm".
      */
     @ConfigItem(defaultValue = "helm")
     public String outputDirectory;

--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -72,7 +73,12 @@ public class HelmProcessor {
     }
 
     private Path getOutputDirectory(HelmChartConfig config, OutputTargetBuildItem outputTarget) {
-        return outputTarget.getOutputDirectory().resolve(config.outputDirectory);
+        Path path = Paths.get(config.outputDirectory);
+        if (!path.isAbsolute()) {
+            return outputTarget.getOutputDirectory().resolve(path);
+        }
+
+        return path;
     }
 
     private Map<String, Set<File>> toDeploymentTargets(List<String> generatedFiles,

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.11.2.Final
+:quarkus-version: 2.12.0.Final
 :quarkus-helm-version: 0.0.5
 :maven-version: 3.8.1+
 

--- a/docs/modules/ROOT/pages/includes/quarkus-helm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-helm.adoc
@@ -146,7 +146,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-helm_quarkus.helm.output-direct
 
 [.description]
 --
-The output folder in which to place the Helm generated folder. By default, it will be generated in the folder named "helm".
+The output folder in which to place the Helm generated folder. The folder is relative to the target output directory in Quarkus that is also configurable using the property `quarkus.package.output-directory`. It also supports absolute paths. By default, it will be generated in the folder named "helm".
 
 Environment variable: `+++QUARKUS_HELM_OUTPUT_DIRECTORY+++`
 --|string 


### PR DESCRIPTION
Fix https://github.com/quarkiverse/quarkus-helm/issues/58