### PR TITLE
Do not append Helm classifier in the tar files

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmChartConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmChartConfig.java
@@ -85,6 +85,11 @@ public class HelmChartConfig {
     String extension;
 
     /**
+     * Classifier to be appended into the generated Helm tarball file.
+     */
+    Optional<String> tarFileClassifier;
+
+    /**
      * If Helm tar file is generated.
      */
     @ConfigItem(defaultValue = "false")

--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
@@ -121,6 +121,7 @@ public class HelmProcessor {
                     dekorateHelmChartConfig,
                     valueReferencesFromConfig,
                     config.expressions.values(),
+                    config.tarFileClassifier,
                     inputFolder,
                     chartOutputFolder,
                     filesInDeploymentTarget.getValue());

--- a/docs/modules/ROOT/pages/includes/quarkus-helm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-helm.adoc
@@ -202,6 +202,20 @@ endif::add-copy-button-to-env-var[]
 |`tar.gz`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-helm_quarkus.helm.tar-file-classifier]]`link:#quarkus-helm_quarkus.helm.tar-file-classifier[quarkus.helm.tar-file-classifier]`
+
+[.description]
+--
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HELM_TAR_FILE_CLASSIFIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_HELM_TAR_FILE_CLASSIFIER+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-helm_quarkus.helm.create-tar-file]]`link:#quarkus-helm_quarkus.helm.create-tar-file[quarkus.helm.create-tar-file]`
 
 [.description]

--- a/integration-tests/helm-kubernetes-with-dependency/src/main/resources/application.properties
+++ b/integration-tests/helm-kubernetes-with-dependency/src/main/resources/application.properties
@@ -4,6 +4,7 @@ quarkus.helm.dependencies.0.repository=https://charts.bitnami.com/bitnami
 
 # Produce tar file: The dependency should be fetched before creating the tar file
 quarkus.helm.create-tar-file=true
+quarkus.helm.tar-file-classifier=helm
 
 quarkus.helm.values.0.property=postgresql.global.postgresql.auth.postgresPassword
 quarkus.helm.values.0.value=secret

--- a/integration-tests/helm-kubernetes-with-dependency/src/test/java/io/quarkiverse/helm/tests/kubernetes/KubernetesWithDependencyIT.java
+++ b/integration-tests/helm-kubernetes-with-dependency/src/test/java/io/quarkiverse/helm/tests/kubernetes/KubernetesWithDependencyIT.java
@@ -24,7 +24,7 @@ public class KubernetesWithDependencyIT {
     @Test
     public void shouldHelmManifestsBeGenerated() throws IOException {
         assertTrue(Stream.of(Paths.get("target", "helm", "kubernetes").toFile().listFiles())
-                .anyMatch(f -> f.getName().startsWith(CHART_NAME) && f.getName().endsWith(".tar.gz")));
+                .anyMatch(f -> f.getName().startsWith(CHART_NAME) && f.getName().endsWith("-helm.tar.gz")));
 
         assertNotNull(getResourceAsStream("charts/postgresql-11.6.22.tgz"));
     }


### PR DESCRIPTION
As this seems to be included with systems like ArgoCD, we are not appending the classifier. Users that still want this behaviour, can use the new property `quarkus.helm.tar-file-classifier=helm` and the generated tar file will be generated as before `<app name>-<app-version>-helm.tar.gz`. I've also checked that this is how the Helm command line behaves when using `helm package <chart name>`.  
Fix https://github.com/quarkiverse/quarkus-helm/issues/110