### PR TITLE
Support of lists in values

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           helm repo update local
 
           # And install application from the Helm repository
-          helm install --devel quarkus-with-templates local/my-chart-with-templates -n $K8S_NAMESPACE --set app.image=$KIND_REGISTRY/$KIND_REGISTRY_GROUP/quarkus-helm-integration-tests-kubernetes-with-templates:$VERSION --set favorite.drink=coca
+          helm install --devel quarkus-with-templates local/my-chart-with-templates -n $K8S_NAMESPACE --set app.image=$KIND_REGISTRY/$KIND_REGISTRY_GROUP/quarkus-helm-integration-tests-kubernetes-with-templates:$VERSION --set app.favorite.drink=coca
           kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=quarkus-helm-integration-tests-kubernetes-with-templates -n $K8S_NAMESPACE
 
           if [ $(kubectl get configmap/my-configmap -n $K8S_NAMESPACE -o yaml | grep "drink: coca" | wc -l) -ne 1 ]
@@ -170,7 +170,7 @@ jobs:
           fi
 
           ## Let's update our Helm chart by not installing the ingress
-          helm upgrade --devel quarkus-with-templates local/my-chart-with-templates -n $K8S_NAMESPACE --set app.image=$KIND_REGISTRY/$KIND_REGISTRY_GROUP/quarkus-helm-integration-tests-kubernetes-with-templates:$VERSION --set favorite.drink=coca --set app.ingress.enabled=false
+          helm upgrade --devel quarkus-with-templates local/my-chart-with-templates -n $K8S_NAMESPACE --set app.image=$KIND_REGISTRY/$KIND_REGISTRY_GROUP/quarkus-helm-integration-tests-kubernetes-with-templates:$VERSION --set app.favorite.drink=coca --set app.ingress.enabled=false
           kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=quarkus-helm-integration-tests-kubernetes-with-templates -n $K8S_NAMESPACE
 
           ## Now, the ingress "my-ingress" should have NOT been installed

--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
@@ -322,6 +322,8 @@ public class HelmProcessor {
             return v.valueAsBool.get();
         } else if (!v.valueAsMap.isEmpty()) {
             return v.valueAsMap;
+        } else if (v.valueAsList.isPresent()) {
+            return v.valueAsList.get();
         }
 
         return v.value.orElse(null);

--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/ValueReferenceConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/ValueReferenceConfig.java
@@ -58,6 +58,13 @@ public class ValueReferenceConfig {
     Map<String, String> valueAsMap;
 
     /**
+     * A list separated by comma that the property will have in the Helm values file.
+     * If not set, the extension will resolve it from the generated artifacts.
+     */
+    @ConfigItem
+    Optional<List<String>> valueAsList;
+
+    /**
      * If not provided, it will use `{{ .Values.<root alias>.<property> }}`.
      *
      * @return The complete Helm expression to be replaced with.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -564,11 +564,11 @@ The Quarkus Helm extension partially supports Helm extensions via https://helm.s
 ----
 # Example of expressions
 quarkus.helm.expressions.0.path=(kind == Service).metadata.annotations.'app.quarkus.io/commit-id'
-quarkus.helm.expressions.0.expression={{ .Values.favorite.drink | default "tea" | quote }}
+quarkus.helm.expressions.0.expression={{ .Values.app.favorite.drink | default "tea" | quote }}
 
 # Example of multiline expression
 quarkus.helm.expressions.1.path=(kind == ConfigMap && metadata.name == my-configmap).data
-quarkus.helm.expressions.1.expression={{- range $key, $val := .Values.favorite }}\n\
+quarkus.helm.expressions.1.expression={{- range $key, $val := .Values.app.favorite }}\n\
 {{ indent 2 $key }}: {{ $val | quote }}\n\
 {{- end }}
 ----

--- a/integration-tests/helm-kubernetes-with-templates/src/main/kubernetes/kubernetes.yml
+++ b/integration-tests/helm-kubernetes-with-templates/src/main/kubernetes/kubernetes.yml
@@ -5,6 +5,13 @@ metadata:
 data:
   myvalue: "Hello World"
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: names-configmap
+data:
+  myvalue: "Hello World"
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/integration-tests/helm-kubernetes-with-templates/src/main/resources/application.properties
+++ b/integration-tests/helm-kubernetes-with-templates/src/main/resources/application.properties
@@ -6,15 +6,20 @@ quarkus.helm.expressions.0.expression={{ include "foo.name" . }}
 
 # Example of expressions
 quarkus.helm.expressions.1.path=(kind == Service).metadata.annotations.'app.quarkus.io/commit-id'
-quarkus.helm.expressions.1.expression={{ .Values.favorite.drink | default "tea" | quote }}
+quarkus.helm.expressions.1.expression={{ .Values.app.favorite.drink | default "tea" | quote }}
 
 # Example of call templates
 quarkus.helm.expressions.2.path=(kind == Service && metadata.name == quarkus-helm-integration-tests-kubernetes-with-templates).metadata.labels
 quarkus.helm.expressions.2.expression={{- template "mychart.labels" }}
 
 quarkus.helm.expressions.3.path=(kind == ConfigMap && metadata.name == my-configmap).data
-quarkus.helm.expressions.3.expression={{- range $key, $val := .Values.favorite }}\n\
+quarkus.helm.expressions.3.expression={{- range $key, $val := .Values.app.favorite }}\n\
 {{ indent 2 $key }}: {{ $val | quote }}\n\
+{{- end }}
+
+quarkus.helm.expressions.4.path=(kind == ConfigMap && metadata.name == names-configmap).data
+quarkus.helm.expressions.4.expression={{- range .Values.app.names }}\n\
+{{ indent 2 . }}: {{ . | quote }}\n\
 {{- end }}
 
 # Condition as resource level
@@ -35,3 +40,5 @@ quarkus.helm.add-if-statement."ingress.enabled".with-default-value=true
 
 quarkus.helm.values.favorite.value-as-map.car=Ford
 quarkus.helm.values.favorite.value-as-map.fruit=Apple
+
+quarkus.helm.values.names.value-as-list=John,Locke

--- a/integration-tests/helm-kubernetes-with-templates/src/test/resources/expected-configmap.yaml
+++ b/integration-tests/helm-kubernetes-with-templates/src/test/resources/expected-configmap.yaml
@@ -3,6 +3,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: my-configmap
-data: {{- range $key, $val := .Values.favorite }}
+data: {{- range $key, $val := .Values.app.favorite }}
 {{ indent 2 $key }}: {{ $val | quote }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: names-configmap
+data: {{- range .Values.app.names }}
+{{ indent 2 . }}: {{ . | quote }}
 {{- end }}


### PR DESCRIPTION
Now, we can define a list of values (string separated by comma). For example:
```
quarkus.helm.values.names.value-as-list=John,Locke
```

This will be transformed into:

_Values.yaml_:
```yaml
---
app:
  names:
    - John
    - Locke
```