### PR TITLE
Add new property to disable the naming validation

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmChartConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmChartConfig.java
@@ -222,6 +222,13 @@ public class HelmChartConfig {
     public boolean mapSystemProperties;
 
     /**
+     * If true, the naming validation will be disabled.
+     * The naming validation rejects property names that contain "-" characters.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean disableNamingValidation;
+
+    /**
      * Configuration for the `values.schema.json` file.
      */
     public ValuesSchemaConfig valuesSchema;

--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
@@ -233,27 +233,34 @@ public class HelmProcessor {
                         addIfStatement.getKey(), addIfStatement.getKey()));
             }
 
-            if (HELM_INVALID_CHARACTERS.stream().anyMatch(name::contains)) {
+            if (!config.disableNamingValidation && HELM_INVALID_CHARACTERS.stream().anyMatch(name::contains)) {
                 throw new RuntimeException(
-                        String.format("The property of the `add-if-statement` '%s' is invalid. Can't use '-' characters.",
-                                name));
+                        String.format("The property of the `add-if-statement` '%s' is invalid. Can't use '-' characters."
+                                + "You can disable the naming validation using "
+                                + "`quarkus.helm.disable-naming-validation=true`", name));
             }
         }
 
-        for (Map.Entry<String, HelmDependencyConfig> dependency : config.dependencies.entrySet()) {
-            String name = dependency.getValue().name.orElse(dependency.getKey());
-            if (dependency.getValue().condition.isPresent()
-                    && HELM_INVALID_CHARACTERS.stream().anyMatch(dependency.getValue().condition.get()::contains)) {
-                throw new RuntimeException(
-                        String.format("Condition of the dependency '%s' is invalid. Can't use '-' characters.", name));
+        if (!config.disableNamingValidation) {
+            for (Map.Entry<String, HelmDependencyConfig> dependency : config.dependencies.entrySet()) {
+                String name = dependency.getValue().name.orElse(dependency.getKey());
+                if (dependency.getValue().condition.isPresent()
+                        && HELM_INVALID_CHARACTERS.stream().anyMatch(dependency.getValue().condition.get()::contains)) {
+                    throw new RuntimeException(
+                            String.format("Condition of the dependency '%s' is invalid. Can't use '-' characters."
+                                    + "You can disable the naming validation using "
+                                    + "`quarkus.helm.disable-naming-validation=true`", name));
+                }
             }
-        }
 
-        for (Map.Entry<String, ValueReferenceConfig> value : config.values.entrySet()) {
-            String name = value.getValue().property.orElse(value.getKey());
-            if (HELM_INVALID_CHARACTERS.stream().anyMatch(name::contains)) {
-                throw new RuntimeException(
-                        String.format("Property of the value '%s' is invalid. Can't use '-' characters.", name));
+            for (Map.Entry<String, ValueReferenceConfig> value : config.values.entrySet()) {
+                String name = value.getValue().property.orElse(value.getKey());
+                if (HELM_INVALID_CHARACTERS.stream().anyMatch(name::contains)) {
+                    throw new RuntimeException(
+                            String.format("Property of the value '%s' is invalid. Can't use '-' characters."
+                                    + "You can disable the naming validation using "
+                                    + "`quarkus.helm.disable-naming-validation=true`", name));
+                }
             }
         }
     }

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.0.0.Final
+:quarkus-version: 3.0.2.Final
 :quarkus-helm-version: 1.0.5
 :maven-version: 3.8.1+
 

--- a/docs/modules/ROOT/pages/includes/quarkus-helm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-helm.adoc
@@ -507,6 +507,22 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-helm_quarkus.helm.disable-naming-validation]]`link:#quarkus-helm_quarkus.helm.disable-naming-validation[quarkus.helm.disable-naming-validation]`
+
+[.description]
+--
+If true, the naming validation will be disabled. The naming validation rejects property names that contain "-" characters.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HELM_DISABLE_NAMING_VALIDATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_HELM_DISABLE_NAMING_VALIDATION+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-helm_quarkus.helm.values-schema.title]]`link:#quarkus-helm_quarkus.helm.values-schema.title[quarkus.helm.values-schema.title]`
 
 [.description]

--- a/integration-tests/helm-kubernetes-full/src/main/resources/application.properties
+++ b/integration-tests/helm-kubernetes-full/src/main/resources/application.properties
@@ -19,6 +19,7 @@ quarkus.helm.dependencies.1.repository=http://localhost:8080
 quarkus.helm.dependencies.1.condition=app.dependencyBeEnabled
 # Validation
 quarkus.helm.values-schema.properties.replicas.minimum=3
+quarkus.helm.disable-naming-validation=true
 # Maintainers
 quarkus.helm.maintainers.user1.email=user@group.com
 # When path is not found
@@ -40,6 +41,8 @@ quarkus.helm.values.5.value-as-bool=true
 quarkus.helm.values.host.value=override-host-in-helm
 # Rootless property
 quarkus.helm.values."@.prop".value=rootless-property
+# Dash property
+quarkus.helm.values."my-prop".value=test
 # Resteasy Reactive
 quarkus.resteasy-reactive.path=${OVERRIDE_PATH}
 quarkus.host.port=${OVERRIDE_PORT:8080}

--- a/integration-tests/helm-kubernetes-full/src/test/java/io/quarkiverse/helm/tests/kubernetes/KubernetesFullIT.java
+++ b/integration-tests/helm-kubernetes-full/src/test/java/io/quarkiverse/helm/tests/kubernetes/KubernetesFullIT.java
@@ -75,6 +75,8 @@ public class KubernetesFullIT {
         assertEquals("bar", app.get("foo"));
         // Should add properties set as conditions in dependencies
         assertEquals(true, app.get("dependencyBeEnabled"));
+        // Should contain "my-prop" because validation is disabled
+        assertEquals("test", app.get("my-prop"));
 
         Map<String, Object> dependencyA = (Map<String, Object>) values.get("depA");
         // Should have properties from custom values.yaml file


### PR DESCRIPTION
These changes add a new property `quarkus.helm.disable-naming-validation` that allows disabling the naming validation.

To give more context: the names that contain a dash ("-") are rejected when installing a Helm chart using the Helm command line (this is a Helm command line limitation). 

Though, some users want to still use names with dash because they won't use the Helm command line to install the Helm charts. 