### PR TITLE
Prop values profile separator

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmChartConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmChartConfig.java
@@ -229,6 +229,13 @@ public class HelmChartConfig {
     public boolean disableNamingValidation;
 
     /**
+     * Configuration for the separator string in the filename of profile specific values files i.e. values.profile.yaml,
+     * defaults to "."
+     */
+    @ConfigItem(defaultValue = ".")
+    public String valuesProfileSeparator;
+
+    /**
      * Configuration for the `values.schema.json` file.
      */
     public ValuesSchemaConfig valuesSchema;

--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
@@ -203,7 +203,8 @@ public class HelmProcessor {
                     getConfigReferencesFromSession(deploymentTarget, dekorateOutput),
                     inputFolder,
                     chartOutputFolder,
-                    filesInDeploymentTarget.getValue());
+                    filesInDeploymentTarget.getValue(),
+                    config.valuesProfileSeparator);
 
             // Push to Helm repository if enabled
             if (config.repository.push && deploymentTargetToPush.equals(deploymentTarget)) {

--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/QuarkusHelmWriterSessionListener.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/QuarkusHelmWriterSessionListener.java
@@ -114,7 +114,8 @@ public class QuarkusHelmWriterSessionListener {
             List<ConfigReference> valueReferencesFromDecorators,
             Path inputDir,
             Path outputDir,
-            Collection<File> generatedFiles) {
+            Collection<File> generatedFiles,
+            String valuesProfileSeparator) {
         Map<String, String> artifacts = new HashMap<>();
         if (helmConfig.isEnabled()) {
             validateHelmConfig(helmConfig);
@@ -126,7 +127,7 @@ public class QuarkusHelmWriterSessionListener {
                         valueReferencesFromUser, valueReferencesFromDecorators);
                 artifacts.putAll(processTemplates(helmConfig, helmConfig.getAddIfStatements(), inputDir, outputDir, resources));
                 artifacts.putAll(createChartYaml(helmConfig, project, inputDir, outputDir));
-                artifacts.putAll(createValuesYaml(helmConfig, inputDir, outputDir, values));
+                artifacts.putAll(createValuesYaml(helmConfig, inputDir, outputDir, values, valuesProfileSeparator));
 
                 // To follow Helm file structure standards:
                 artifacts.putAll(createEmptyChartFolder(helmConfig, outputDir));
@@ -247,7 +248,7 @@ public class QuarkusHelmWriterSessionListener {
     }
 
     private Map<String, String> createValuesYaml(io.dekorate.helm.config.HelmChartConfig helmConfig,
-            Path inputDir, Path outputDir, ValuesHolder valuesHolder)
+            Path inputDir, Path outputDir, ValuesHolder valuesHolder, String valuesProfileSeparator)
             throws IOException {
         Map<String, ValuesHolder.HelmValueHolder> prodValues = valuesHolder.getProdValues();
         Map<String, Map<String, ValuesHolder.HelmValueHolder>> valuesByProfile = valuesHolder.getValuesByProfile();
@@ -267,7 +268,8 @@ public class QuarkusHelmWriterSessionListener {
 
             // Create the values.<profile>.yaml file
             artifacts.putAll(writeFileAsYaml(mergeWithFileIfExists(inputDir, VALUES + YAML, toValuesMap(values)),
-                    getChartOutputDir(helmConfig, outputDir).resolve(VALUES + "." + profile + YAML)));
+                    getChartOutputDir(helmConfig, outputDir)
+                            .resolve(VALUES + valuesProfileSeparator + profile + YAML)));
         }
 
         // Next, we process the prod profile

--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/ValueReferenceConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/ValueReferenceConfig.java
@@ -25,7 +25,7 @@ public class ValueReferenceConfig {
 
     /**
      * The profile where this value reference will be mapped to.
-     * For example, if the profile is `dev`, then a `values-dev.yml` file will be created with the value.
+     * For example, if the profile is `dev`, then a `values.dev.yml` file will be created with the value.
      */
     @ConfigItem
     Optional<String> profile;

--- a/docs/modules/ROOT/pages/includes/quarkus-helm.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-helm.adoc
@@ -523,6 +523,22 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-helm_quarkus.helm.values-profile-separator]]`link:#quarkus-helm_quarkus.helm.values-profile-separator[quarkus.helm.values-profile-separator]`
+
+[.description]
+--
+Configuration for the separator string in the filename of profile specific values files i.e. values.profile.yaml, defaults to "."
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HELM_VALUES_PROFILE_SEPARATOR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_HELM_VALUES_PROFILE_SEPARATOR+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`.`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-helm_quarkus.helm.values-schema.title]]`link:#quarkus-helm_quarkus.helm.values-schema.title[quarkus.helm.values-schema.title]`
 
 [.description]
@@ -815,7 +831,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-helm_quarkus.helm.values.-value
 
 [.description]
 --
-The profile where this value reference will be mapped to. For example, if the profile is `dev`, then a `values-dev.yml` file will be created with the value.
+The profile where this value reference will be mapped to. For example, if the profile is `dev`, then a `values.dev.yml` file will be created with the value.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_HELM_VALUES__VALUES__PROFILE+++[]

--- a/integration-tests/helm-kubernetes-full/src/main/resources/application.properties
+++ b/integration-tests/helm-kubernetes-full/src/main/resources/application.properties
@@ -8,6 +8,7 @@ quarkus.kubernetes.annotations.foo=bar
 quarkus.kubernetes.env.vars.OVERRIDE_PORT=8081
 # Container image
 quarkus.container-image.image=registry.com/name:version
+quarkus.helm.values-profile-separator=-
 # Dependencies
 quarkus.helm.dependencies.dependency-name-a.version=0.0.1
 quarkus.helm.dependencies.dependency-name-a.alias=depA

--- a/integration-tests/helm-kubernetes-full/src/test/java/io/quarkiverse/helm/tests/kubernetes/KubernetesFullIT.java
+++ b/integration-tests/helm-kubernetes-full/src/test/java/io/quarkiverse/helm/tests/kubernetes/KubernetesFullIT.java
@@ -29,7 +29,7 @@ public class KubernetesFullIT {
         assertNotNull(getResourceAsStream("README.md"));
         assertNotNull(getResourceAsStream("requirements.yml"));
         assertNotNull(getResourceAsStream("values.schema.json"));
-        assertNotNull(getResourceAsStream("values.dev.yaml"));
+        assertNotNull(getResourceAsStream("values-dev.yaml"));
         assertNotNull(getResourceAsStream("templates/deployment.yaml"));
         assertNotNull(getResourceAsStream("templates/NOTES.txt"));
         assertNotNull(getResourceAsStream("crds/crontabs.stable.example.com.yaml"));
@@ -112,7 +112,7 @@ public class KubernetesFullIT {
     @Test
     public void valuesShouldContainExpectedDataInDevProfile() throws IOException {
         Map<String, Object> values = Serialization.yamlMapper()
-                .readValue(getResourceAsStream("values.dev.yaml"),
+                .readValue(getResourceAsStream("values-dev.yaml"),
                         Map.class);
         assertNotNull(values, "Values is null!");
 


### PR DESCRIPTION
### What?
Add an additional config string property "quarkus.helm.values-profile-separator" to configure the separator string used to separate "values" and {profile} in generated profile-specific values.yaml files. Defaults to "."; therefore, a values file for the profile "dev" would be named values.dev.yaml. If the property is set to "-" the resulting filename would be values-dev.yaml. 
### Why?
This makes it easier to include the generated Helm Chart in existing CD pipelines, where stage-specific overrides are already configured.
### Tests included?
Yes, KubernetesFullIT has been modified to utilize the new property.
