### PR TITLE
Fix all asciidoc warnings

### DIFF
--- a/docs/modules/ROOT/pages/example-crud.adoc
+++ b/docs/modules/ROOT/pages/example-crud.adoc
@@ -1,6 +1,8 @@
 [[example-crud]]
 = Example: How to generate the Helm Chart of a REST CRUD Quarkus application
 
+include::./includes/attributes.adoc[]
+
 In this example, we're going to create a very simple REST CRUD application in Quarkus. Then, we'll configure it to build the application image, and push it to a container registry, so Kubernetes can pull this image from. Next, we'll configure the Quarkus Kubernetes and Helm extensions to generate the Helm chart and push it into a Helm repository. Finally, we'll see how to install the generated Helm chart into Kubernetes from the Helm repository.
 
 == Prerequisites
@@ -49,7 +51,7 @@ public class GreetingResource {
 }
 ----
 
-So, if we start our application, for example running the Maven command `mvn quarkus:dev` (Quarkus DEV mode) , we could call it using `http://localhost:8080/hello`.
+So, if we start our application, for example running the Maven command `mvn quarkus:dev` (Quarkus DEV mode), we could call it using `http://localhost:8080/hello`.
 
 To continue with, let's add our first Fruit entity:
 


### PR DESCRIPTION
Asciidoc interprets strings like ${quarkus-version} as attributes and then issues a WARN during the build that it will skip reference to a missing attribute. This PR adds an inclusion of attributes file to the `example-crud.adoc`.

Proof of all warnings gone:
<img width="977" alt="image" src="https://github.com/quarkiverse/quarkus-helm/assets/11942401/03bda87f-b2d4-476a-83ea-3c43207bbeb6">

Proof of warnings before this PR:
<img width="873" alt="image" src="https://github.com/quarkiverse/quarkus-helm/assets/11942401/b1d1f0dc-6054-4b2f-88d2-f55d4bdca15f">
