### PR TITLE
fix: respect YamlConfigSource (#367)

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/helm/deployment/HelmProcessor.java
@@ -68,6 +68,7 @@ public class HelmProcessor {
     private static final String SERVICE_PORT_PLACEHOLDER = "::service-port";
     private static final String SPLIT = ":";
     private static final String PROPERTIES_CONFIG_SOURCE = "PropertiesConfigSource";
+    private static final String YAML_CONFIG_SOURCE = "YamlConfigSource";
     // Lazy loaded when calling `isBuildTimeProperty(xxx)`.
     private static Set<String> buildProperties;
 
@@ -411,7 +412,8 @@ public class HelmProcessor {
     }
 
     private boolean isPropertiesConfigSource(String sourceName) {
-        return StringUtils.isNotEmpty(sourceName) && sourceName.startsWith(PROPERTIES_CONFIG_SOURCE);
+        return StringUtils.isNotEmpty(sourceName)
+                && (sourceName.startsWith(PROPERTIES_CONFIG_SOURCE) || sourceName.startsWith(YAML_CONFIG_SOURCE));
     }
 
     private boolean isBuildTimeProperty(String name) {

--- a/integration-tests/helm-kubernetes-minimal-yaml/pom.xml
+++ b/integration-tests/helm-kubernetes-minimal-yaml/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.quarkiverse.helm</groupId>
+    <artifactId>quarkus-helm-integration-tests</artifactId>
+    <version>1.2.5-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>quarkus-helm-integration-tests-kubernetes-minimal-yaml</artifactId>
+  <name>Quarkus - Helm - Integration Tests - Kubernetes - Minimal - Yaml config source</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-reactive</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-container-image-jib</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-config-yaml</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkiverse.helm</groupId>
+      <artifactId>quarkus-helm</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>dekorate-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/integration-tests/helm-kubernetes-minimal-yaml/src/main/java/io/quarkiverse/helm/tests/kubernetes/Endpoint.java
+++ b/integration-tests/helm-kubernetes-minimal-yaml/src/main/java/io/quarkiverse/helm/tests/kubernetes/Endpoint.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.helm.tests.kubernetes;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("")
+public class Endpoint {
+
+    @GET
+    public String hello() {
+        return "Hello, World!";
+    }
+}

--- a/integration-tests/helm-kubernetes-minimal-yaml/src/main/resources/application.yaml
+++ b/integration-tests/helm-kubernetes-minimal-yaml/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+foo:
+  bar: ${FOO_BAR:baz}
+  ~: ${BAR_FOO}

--- a/integration-tests/helm-kubernetes-minimal-yaml/src/test/java/io/quarkiverse/helm/tests/kubernetes/KubernetesYamlConfigSourceIT.java
+++ b/integration-tests/helm-kubernetes-minimal-yaml/src/test/java/io/quarkiverse/helm/tests/kubernetes/KubernetesYamlConfigSourceIT.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.helm.tests.kubernetes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.utils.Serialization;
+
+public class KubernetesYamlConfigSourceIT {
+    private static final String CHART_NAME = "quarkus-helm-integration-tests-kubernetes-minimal-yaml";
+    private static final String ROOT_CONFIG_NAME = "app";
+
+    @Test
+    public void shouldHelmManifestsBeGenerated() throws IOException {
+        Map chart = Serialization.yamlMapper()
+                .readValue(getResourceAsStream("Chart.yaml"), Map.class);
+        assertNotNull(chart, "Chart is null!");
+        assertEquals(CHART_NAME, chart.get("name"));
+        // Values.yaml manifest
+        assertNotNull(getResourceAsStream("values.yaml"));
+        // templates
+        assertNotNull(getResourceAsStream("templates/deployment.yaml"));
+        // notes
+        assertNotNull(getResourceAsStream("templates/NOTES.txt"));
+    }
+
+    @Test
+    public void valuesShouldContainExpectedData() throws IOException {
+        Map<String, Object> values = Serialization.yamlMapper()
+                .readValue(getResourceAsStream("values.yaml"), Map.class);
+        assertNotNull(values, "Values is null!");
+
+        assertNotNull(values.containsKey(ROOT_CONFIG_NAME), "Does not contain `" + ROOT_CONFIG_NAME + "`");
+        assertNotNull(values.get(ROOT_CONFIG_NAME) instanceof Map, "Value `" + ROOT_CONFIG_NAME + "` is not a map!");
+        Map<String, Object> helmExampleValues = (Map<String, Object>) values.get(ROOT_CONFIG_NAME);
+        // Should contain image
+        assertNotNull(helmExampleValues.get("image"));
+
+        final var envs = (HashMap<String, String>) helmExampleValues.get("envs");
+        assertEquals("baz", envs.get("FOO_BAR"));
+        assertEquals("", envs.get("BAR_FOO"));
+    }
+
+    private InputStream getResourceAsStream(String file) throws FileNotFoundException {
+        return new FileInputStream(Paths.get("target", "helm", "kubernetes").resolve(CHART_NAME).resolve(file).toFile());
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -13,6 +13,7 @@
 
   <modules>
     <module>helm-kubernetes-minimal</module>
+    <module>helm-kubernetes-minimal-yaml</module>
     <module>helm-kubernetes-with-dependency</module>
     <module>helm-kubernetes-config</module>
     <module>helm-kubernetes-with-templates</module>


### PR DESCRIPTION
Issue: https://github.com/quarkiverse/quarkus-helm/issues/367

Fix is trivial so I didn't write any test :)
I can write it, just tell me where to put it...
- in a new module called `helm-kubernetes-minimal-yaml` 
- or 
-  I add `quarkus-config-yaml` extension and a simple test inside `helm-kubernetes-minimal`? 