### PR TITLE
Add io.quarkiverse.helm.crd-support capability definition

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -43,6 +43,11 @@
             <configuration>
               <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
               </deployment>
+              <capabilities>
+                <provides>
+                  <capability>io.quarkiverse.helm.crd-support</capability>
+                </provides>
+              </capabilities>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
We can use this in QOSDK to get a better error message if quarkus-helm with lower version than required is being used.